### PR TITLE
Handle unknown message types from Slack RTM API

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -190,7 +190,7 @@ console.log(Object.keys(bot))
 
 // do something with the rtm.start payload
 bot.started(function(payload) {
-  console.log('payload from rtm.start', paylod)
+  console.log('payload from rtm.start', payload)
 })
 
 // respond to a user_typing message

--- a/src/rtm.client-browser.js
+++ b/src/rtm.client-browser.js
@@ -35,7 +35,13 @@ export default function client() {
         // delegate everything
         bot.ws.onmessage = function message(e) {
           let json = JSON.parse(e.data)
-          bot.handlers[json.type].forEach(m=> m.call({}, json))
+          let handler = bot.handlers[json.type]
+          if (handler) {
+            handler.forEach(m=> m.call({}, json))
+          }
+          else {
+            console.error("Unknown message type: " + json);
+          }
         }
         // call started callbacks
         bot.handlers['started'].forEach(m=> m.call({}, data))


### PR DESCRIPTION
I hit an exception running slack@5.2.2 from npm, which clearly looks like a case where an unknown message was received. Not sure what the right solution would be in the error case, but there was another console.error in this file, so went with that. Perhaps an exception is the correct result here though, in which case there should be a custom Error should be thrown that captures the message for future correction.

/node_modules/slack/methods/rtm.client.js:52
        bot.handlers[json.type].forEach(function (m) {
                               ^

TypeError: Cannot read property 'forEach' of undefined
    at WebSocket.message (/node_modules/slack/methods/rtm.client.js:52:32)
    at emitTwo (events.js:87:13)
    at WebSocket.emit (events.js:172:7)
    at Receiver.ontext (/node_modules/slack/node_modules/ws/lib/WebSocket.js:816:10)
    at /node_modules/slack/node_modules/ws/lib/Receiver.js:477:18
    at Receiver.applyExtensions (/node_modules/slack/node_modules/ws/lib/Receiver.js:364:5)
    at /node_modules/slack/node_modules/ws/lib/Receiver.js:466:14
    at Receiver.flush (/node_modules/slack/node_modules/ws/lib/Receiver.js:340:3)
    at Receiver.opcodes.1.finish (/node_modules/slack/node_modules/ws/lib/Receiver.js:482:12)
    at Receiver.expectHandler (/node_modules/slack/node_modules/ws/lib/Receiver.js:457:31)