### PR TITLE
Moved lodash to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "cheerio": "^0.19.0",
     "envify": "^3.4.0",
     "glob": "^6.0.1",
+    "lodash": "^4.5.0",
     "node-env-file": "^0.1.8",
     "tap": "^2.3.1",
     "tap-spec": "^4.1.1",
@@ -48,7 +49,6 @@
   },
   "dependencies": {
     "httpplease": "^0.16.4",
-    "lodash": "^4.5.0",
     "query-string": "^3.0.0",
     "request": "^2.67.0",
     "ws": "^1.0.1"


### PR DESCRIPTION
It appears that `lodash` is only used in `scripts/generate-stateful-client`. Since `babel` is only used as a devDependency, I thought it might be better to place `lodash` in there, also.