### PR TITLE
Make 'file' parameter in files.upload optional

### DIFF
--- a/src/api.json
+++ b/src/api.json
@@ -1351,7 +1351,7 @@
     {
       "name": "file",
       "example": "...",
-      "required": "Required",
+      "required": "Optional",
       "description": "File contents via multipart/form-data.\n"
     },
     {


### PR DESCRIPTION
Per the Slack Web API docs, `file` itself is optional, but the request is invalid if _both_ `file` and `content` are absent.

See: https://api.slack.com/methods/files.upload