### PR TITLE
Remove requirement to pass token to factory

### DIFF
--- a/src/_factory.js
+++ b/src/_factory.js
@@ -14,14 +14,13 @@ var exec = require('./_exec')
  */
 module.exports = function factory(xxx) {
   
-  if (!xxx) throw ReferenceError('missing params; params.token is required')
-  if (!xxx.token) throw ReferenceError('missing params.token; params.token is required')
+  if (!xxx) xxx = {}
 
   // Slack instance applies the token param to all the api methods
   class Slack {
     constructor() {
       function _execWithToken(method, params, callback) {
-        params.token = xxx.token
+        params.token = params.token || xxx.token
         return exec(method, params, callback)
       }
       // bind applies the above method to this obj

--- a/test/class-test.js
+++ b/test/class-test.js
@@ -5,15 +5,17 @@ test('class ctor factory validates', t=> {
   t.plan(2)
   try {
     var bot = new Slack
+    t.ok(bot)
   }
   catch(e) {
-    t.ok(e, e) 
+    t.fail() 
   }
   try {
     var bot = new Slack({})
+    t.ok(bot)
   }
   catch(e) {
-    t.ok(e, e) 
+    t.fail() 
   }
 })
 


### PR DESCRIPTION
There are situations where you may want to conditionally use a user token or a bot token in an app. Since you may pass the `token` as a param to each function, it seems inflexible to require it be passed to the factory function. This change allows `token` to be passed in the factory and allows the token to be overridden if passed as a param to a method.

