### PR TITLE
adds quick explanation of where to find response_metadata

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -65,6 +65,15 @@ let bot = new Slack({token})
 
 Choose whichever style works best for your project deployment needs and team preference. It is definitely worth examining what style is more concise, expressive and deterministic. It is also worth noticing how these properties can change between runtime versions. :hearts::beer:
 
+### Error Handling
+Some methods (like [`slack.dialog.open`](https://api.slack.com/methods/dialog.open)) provide additional context for errors through a `response_metadata` object. This will be exposed as a `messages` properties on the errors that are thrown.
+
+```javascript
+slack.dialog.open(options).catch(err => {
+  console.log(err.messages)
+})
+```
+
 ### Test Setup :lock::key::point_left:
 
 Clone this repo and create a file called `.env` in the root with the following:

--- a/readme.tmpl
+++ b/readme.tmpl
@@ -65,6 +65,15 @@ let bot = new Slack({token})
 
 Choose whichever style works best for your project deployment needs and team preference. It is definitely worth examining what style is more concise, expressive and deterministic. It is also worth noticing how these properties can change between runtime versions. :hearts::beer:
 
+### Error Handling
+Some methods (like [`slack.dialog.open`](https://api.slack.com/methods/dialog.open)) provide additional context for errors through a `response_metadata` object. This will be exposed as a `messages` properties on the errors that are thrown.
+
+```javascript
+slack.dialog.open(options).catch(err => {
+  console.log(err.messages)
+})
+```
+
 ### Test Setup :lock::key::point_left:
 
 Clone this repo and create a file called `.env` in the root with the following:


### PR DESCRIPTION
Following on from discussion in #82, just added a section to the readme that explains how the context from inside `response_metadata` object is forwarded in the errors that this package throws.

