### PR TITLE
one less dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "tape": "^4.6.0"
   },
   "dependencies": {
-    "tiny-json-http": "^5.1.0",
-    "util.promisify": "^1.0.0"
+    "tiny-json-http": "^5.1.0"
   }
 }

--- a/src/_exec.js
+++ b/src/_exec.js
@@ -1,6 +1,6 @@
 var http = require('tiny-json-http')
 var validate = require('./_validate')
-var promisify = require('util.promisify')
+var promisify = require('./_promisify')
 
 /**
  * returns a promise if callback isn't defined; _exec is the actual impl

--- a/src/_promisify.js
+++ b/src/_promisify.js
@@ -1,0 +1,16 @@
+module.exports = function _promisify(orig) {
+  return function(...args) {
+    return new Promise(function(resolve, reject) {
+      function errback(err, result) {
+        if (err) {
+          reject(err)
+        }
+        else {
+          resolve(result)
+        }
+      }
+      args.push(errback)
+      orig.apply({}, args)
+    })
+  }
+}


### PR DESCRIPTION
cc @mbrevoort && @spencermountain 

noticed the official `utils.promisify` polyfill was 1MB on disk in `node_modules` and quickly wrote this probably naive impl; now a standalone build of this lib for node is 11kb (the browser impl stays the same at 7kb)
