### PR TITLE
steno/testing integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ slack.min.js
 .nyc_output
 slack.node.js
 slack.node.min.js
+slack-testing.js
+slack-testing.min.js

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "cov": "nyc tape test/*-test.js",
     "btest": "./scripts/browser-test | browser-run | tap-spec",
     "generate": "./scripts/generate-api-json > src/api.json && ./scripts/generate-readme",
-    "pkg": "./scripts/browser-pkg > slack.js && jsmin -o slack.min.js slack.js"
+    "pkg": "./scripts/browser-pkg && jsmin -o slack.min.js slack.js && jsmin -o slack-testing.min.js slack-testing.js"
   },
   "repository": {
     "type": "git",

--- a/scripts/browser-pkg
+++ b/scripts/browser-pkg
@@ -3,6 +3,23 @@ var browserify = require('browserify')
   , path       = require('path')
   , fs         = require('fs')
 
+var files = {
+  output: fs.createWriteStream('slack.js'),
+  testing: fs.createWriteStream('slack-testing.js')
+}
+
 browserify('.')
+  .transform('envify', {
+    'NODE_ENV': 'production',
+    'STENO_URL': false
+  })
   .bundle()
-  .pipe(process.stdout)
+  .pipe(files.output)
+
+browserify('.')
+  .transform('envify', {
+    'NODE_ENV': 'testing',
+    'STENO_URL': false
+  })
+  .bundle()
+  .pipe(files.testing)

--- a/src/_exec-browser.js
+++ b/src/_exec-browser.js
@@ -1,4 +1,5 @@
 let validate = require('./_validate')
+let origin = require('./_origin')
 let encode = encodeURIComponent
 let serialize = o=> Object.keys(o).map(k=> encode(k) + '=' + encode(o[k])).join('&')
 
@@ -45,7 +46,7 @@ async function _exec(url, params, callback) {
       body: serialize(params)
     }
 
-    var res = await fetch(`https://slack.com/api/${url}`, opts)
+    var res = await fetch(`${origin}/api/${url}`, opts)
     var json = await res.json()
 
     if (json.error) {

--- a/src/_exec.js
+++ b/src/_exec.js
@@ -1,6 +1,7 @@
 var http = require('tiny-json-http')
 var validate = require('./_validate')
 var promisify = require('./_promisify')
+var origin = require('./_origin')
 
 /**
  * returns a promise if callback isn't defined; _exec is the actual impl
@@ -35,7 +36,7 @@ function _exec(url, form, callback) {
 
     // always post to slack
     http.post({
-      url: `https://slack.com/api/${url}`,
+      url: `${origin}/api/${url}`,
       headers: {
         'Content-Type': 'application/x-www-form-urlencoded'
       },

--- a/src/_origin.js
+++ b/src/_origin.js
@@ -1,0 +1,14 @@
+var origin = 'https://slack.com'
+
+// if in a test environment assume we're running against steno and forward
+// api requests to the default port
+if (process.env.NODE_ENV === 'testing') {
+  origin = 'http://localhost:3000'
+}
+
+// allow configuring the url if steno is running on a non-standard port/host
+if (process.env.STENO_URL) {
+  origin = process.env.STENO_URL
+}
+
+module.exports = origin


### PR DESCRIPTION
Following up on #87. Here's the rough picture:

* `NODE_ENV=testing` causes `slack` to use http://localhost:3000 (Steno's default) as an origin.
* `STENO_URL=*` allows us to set a custom origin
* `./scripts/browser-pkg` now produces `slack.js` and `slack-testing.js`

If we're going to throw the version numbers from those packages into their names, then we probably want to pull the minification in as a browserify transform, rather than running jsmin as a command afterwards.