### PR TITLE
Documentation: Fixed variable names to match .env file

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -41,7 +41,7 @@ slack.api.test({nice:1}).then(console.log).catch(console.log)
 Due to popular demand an OO style is now supported. For an instance of `Slack` all methods come prebound with the `token` parameter applied.
 
 ```javascript
-const token = process.env.SLACKBOT_TOKEN
+const token = process.env.SLACK_BOT_TOKEN
 const Slack = require('slack')
 const bot = new Slack({token})
 
@@ -52,7 +52,7 @@ bot.api.test({hyper:'card'}).then(console.log)
 Using `async`/`await` in Node 8.x:
 
 ```javascript
-let token = process.env.SLACKBOT_TOKEN
+let token = process.env.SLACK_BOT_TOKEN
 let Slack = require('slack')
 let bot = new Slack({token})
 

--- a/readme.tmpl
+++ b/readme.tmpl
@@ -41,7 +41,7 @@ slack.api.test({nice:1}).then(console.log).catch(console.log)
 Due to popular demand an OO style is now supported. For an instance of `Slack` all methods come prebound with the `token` parameter applied.
 
 ```javascript
-const token = process.env.SLACKBOT_TOKEN
+const token = process.env.SLACK_BOT_TOKEN
 const Slack = require('slack')
 const bot = new Slack({token})
 
@@ -52,7 +52,7 @@ bot.api.test({hyper:'card'}).then(console.log)
 Using `async`/`await` in Node 8.x:
 
 ```javascript
-let token = process.env.SLACKBOT_TOKEN
+let token = process.env.SLACK_BOT_TOKEN
 let Slack = require('slack')
 let bot = new Slack({token})
 


### PR DESCRIPTION
Oh golly hi! I saw that in the main readme.md and readme.tpml you have the following:

```
const token = process.env.SLACKBOT_TOKEN
```

```
let token = process.env.SLACKBOT_TOKEN
```

That was conflicting with the .env set up you have:

```
SLACK_TOKEN=xxxx
SLACK_BOT_TOKEN=xxxx
SLACK_CLIENT_ID=xxxx
SLACK_CLIENT_SECRET=xxxx
```

I updated them to `SLACK_BOT_TOKEN` to match the `.env` file setup you have (plus it makes more sense with the other variables you've set for the keys). Please let me know if I was incorrect in my understanding or if there's anything else you'd like me to do!