### PR TITLE
more helpful stack traces

### DIFF
--- a/src/_exec-browser.js
+++ b/src/_exec-browser.js
@@ -14,10 +14,14 @@ let makeform = o => {
  * returns a promise if callback isn't defined; _exec is the actual impl
  */
 module.exports = function exec(url, params, callback) {
+  // get call stack trace in case we throw later
+  var trace = new Error()
+
   if (!callback) {
     return new Promise(function(resolve, reject) {
       _exec(url, params, function __exec(err, res) {
         if (err) {
+          err.stack = trace.stack.replace(/^Error/, "Error: " + err.message)
           reject(err)
         }
         else {
@@ -27,7 +31,12 @@ module.exports = function exec(url, params, callback) {
     })
   }
   else {
-    _exec(url, params, callback)
+    _exec(url, params, function(err, res) {
+      if (err) {
+        err.stack = trace.stack.replace(/^Error/, "Error: " + err.message)
+      }
+      callback(err, res)
+    })
   }
 }
 

--- a/src/_exec.js
+++ b/src/_exec.js
@@ -7,12 +7,23 @@ var origin = require('./_origin')
  * returns a promise if callback isn't defined; _exec is the actual impl
  */
 module.exports = function exec(url, form, callback) {
+  // get call stack trace in case we throw later
+  var trace = new Error()
+
   if (!callback) {
     var pfy = promisify(_exec)
-    return pfy(url, form)
+    return pfy(url, form).catch(function(err) {
+      err.stack = trace.stack.replace(/^Error/, "Error: " + err.message)
+      throw err
+    })
   }
   else {
-    _exec(url, form, callback)
+    _exec(url, form, function(err, res) {
+      if (err) {
+        err.stack = trace.stack.replace(/^Error/, "Error: " + err.message)
+      }
+      callback(err, res)
+    })
   }
 }
 


### PR DESCRIPTION
Implemented stack trace recovery from #122 for all of the versions of `exec`:

* [`src/_exec.js`](https://github.com/smallwins/slack/blob/f3d7e49bb0dcd93e7ec55da90f8331bd9004632f/src/_exec.js)
* [`src/_exec-browser.js`](https://github.com/smallwins/slack/blob/f3d7e49bb0dcd93e7ec55da90f8331bd9004632f/src/_exec-browser.js)
* [`src/_exec-electron.js`](https://github.com/smallwins/slack/blob/f3d7e49bb0dcd93e7ec55da90f8331bd9004632f/src/_exec-electron.js)