### PR TITLE
Update _exec.js

### DIFF
--- a/src/_exec.js
+++ b/src/_exec.js
@@ -1,4 +1,4 @@
-var http = require('tiny-json-http')
+var http = require('http')
 var validate = require('./_validate')
 var promisify = require('./_promisify')
 var origin = require('./_origin')


### PR DESCRIPTION
'tiny-json-http' needs to be replaced by the standard 'http' module to fix a webpack compiling bug